### PR TITLE
Fixed thunder rendering messing up the light renderer

### DIFF
--- a/src/main/java/paulevs/edenring/mixin/client/ClientLevelMixin.java
+++ b/src/main/java/paulevs/edenring/mixin/client/ClientLevelMixin.java
@@ -32,7 +32,12 @@ public abstract class ClientLevelMixin extends Level {
 			float time = getTimeOfDay(timeDelta);
 			float light = 1.0f - (Mth.cos(time * MHelper.PI2) * 2.0f + 0.2f);
 			light = Mth.clamp(light, 0.0f, 1.0f);
-			light = (1.0F - light) * (1.0F - (getThunderLevel(timeDelta) * 5.0F) / 16.0F);
+			if (getThunderLevel(timeDelta)>1.0F) {
+				light = (1.0F - light) * (1.0F - (getThunderLevel(timeDelta) * 5.0F) / 16.0F);
+			}
+			else {
+				light = (1.0F - light);
+			}
 			info.setReturnValue(light * 0.8F + 0.2F);
 		}
 	}


### PR DESCRIPTION
Rendering of thunder light effects made the light level equal zero at night, current approach skips rendering of said thunder light effect on blocks since that appears to be broken. :)