### PR TITLE
Altered mixin targeting for compatibility

### DIFF
--- a/src/main/java/paulevs/edenring/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/paulevs/edenring/mixin/common/LivingEntityMixin.java
@@ -1,20 +1,19 @@
 package paulevs.edenring.mixin.common;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import paulevs.edenring.EdenRing;
 import paulevs.edenring.world.GravityController;
 
-@Mixin(LivingEntity.class)
+@Mixin(value = LivingEntity.class)
 public class LivingEntityMixin {
-	@ModifyConstant(method = "travel", constant = @Constant(doubleValue = 0.08D))
+	@ModifyExpressionValue(method = "travel", at = @At( value = "CONSTANT", args = "doubleValue=0.08D"))
 	private double eden_changeGravity(double gravity) {
 		LivingEntity entity = LivingEntity.class.cast(this);
 		if (entity.level().dimension() == EdenRing.EDEN_RING_KEY) {


### PR DESCRIPTION
Altered the changeGravity mixin from ChangeConstant to the friendlier ModifyExpressionValue targeting. Resolves issues including Eden Ring with other mods which mix into the travel method of LivingEntity.